### PR TITLE
Fix loading dots visibility and asset paths

### DIFF
--- a/frontend/src/app/loading.css
+++ b/frontend/src/app/loading.css
@@ -335,22 +335,23 @@
 
 .loading-dots {
   display: inline-block;
-  min-width: 2ch;
+  min-width: 3ch;
   position: relative;
   z-index: 999999999 !important; /* Maximum z-index to ensure dots appear above everything */
-  background: rgba(255, 0, 0, 0.2); /* Temporary red background for debugging */
+  background: transparent;
   overflow: visible;
-  border: 1px solid rgba(255, 0, 0, 0.5); /* Temporary red border for debugging */
+  margin-left: 4px; /* Space between text and dots */
 }
 
 .loading-dots::after {
   content: ".";
   animation: loadingDots 1.5s infinite;
-  color: #9ca3af !important;
-  font-weight: normal;
+  color: #ffffff !important; /* Bright white for visibility */
+  font-weight: bold !important; /* Make it bolder */
+  font-size: 1.2em !important; /* Slightly larger */
   display: inline-block;
   text-align: left;
-  min-width: 2ch; /* Reserve space for up to 3 dots */
+  min-width: 3ch; /* Reserve space for up to 3 dots */
   position: relative;
   z-index: 999999999 !important;
   background: transparent;
@@ -358,6 +359,7 @@
   letter-spacing: 0.1em;
   visibility: visible !important;
   opacity: 1 !important;
+  text-shadow: 0 0 4px rgba(255, 255, 255, 0.8) !important; /* Add glow effect */
 }
 
 /* Ensure the loading screen disappears after animation */

--- a/frontend/src/components/LoadingManager.tsx
+++ b/frontend/src/components/LoadingManager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useLoading } from "@/contexts/LoadingContext";
+import { useAssetPath } from "@/hooks/useAssetPath";
 
 interface LoadingManagerProps {
   children: React.ReactNode;
@@ -12,6 +13,7 @@ export default function LoadingManager({
   loadingText,
 }: LoadingManagerProps) {
   const { isLoading } = useLoading();
+  const { getAssetPath } = useAssetPath();
 
   return (
     <div
@@ -27,7 +29,7 @@ export default function LoadingManager({
               <div className="portal-mask-left">
                 <div className="logo-right">
                   <img
-                    src="/images/logo_right.png"
+                    src={getAssetPath("/images/logo_right.png")}
                     alt="Logo Right"
                     className="logo-image"
                   />
@@ -40,7 +42,7 @@ export default function LoadingManager({
               <div className="portal-mask-right">
                 <div className="logo-left">
                   <img
-                    src="/images/logo_left.png"
+                    src={getAssetPath("/images/logo_left.png")}
                     alt="Logo Left"
                     className="logo-image"
                   />


### PR DESCRIPTION
- Changed loading dots color to bright white (#ffffff) with glow effect
- Increased font size and weight for better visibility
- Fixed logo asset paths in LoadingManager using getAssetPath hook
- Removed debugging background colors and logs
- Added margin and improved spacing for loading dots
- Ensured compatibility with GitHub Pages deployment