### PR TITLE
Fix search image URLs for GitHub Pages deployment

### DIFF
--- a/frontend/src/components/AdvancedSearch.tsx
+++ b/frontend/src/components/AdvancedSearch.tsx
@@ -139,8 +139,8 @@ export default function AdvancedSearch({ isOpen, onClose, onNavigate, currentLan
         modelingRes.json?.() || []
       ]);
 
-      // Pass current language to build language-specific index
-      const dynamicItems = buildDynamicSearchIndex(works, artworks, modeling, currentLanguage || 'ja', translate);
+      // Pass current language to build language-specific index with getAssetPath for proper URLs
+      const dynamicItems = buildDynamicSearchIndex(works, artworks, modeling, currentLanguage || 'ja', translate, getAssetPath);
       setDynamicIndex(dynamicItems);
     } catch (error) {
       console.warn('Failed to load dynamic search data:', error);

--- a/frontend/src/utils/searchIndex.ts
+++ b/frontend/src/utils/searchIndex.ts
@@ -346,7 +346,8 @@ export function buildDynamicSearchIndex(
   artworks: any[] = [],
   modelings: any[] = [],
   currentLanguage: string = 'ja',
-  t?: (key: string) => string
+  t?: (key: string) => string,
+  getAssetPath?: (path: string) => string
 ): SearchItem[] {
   const dynamicItems: SearchItem[] = [];
   
@@ -421,8 +422,12 @@ export function buildDynamicSearchIndex(
   
   // Add artworks
   for (const artwork of artworks) {
-    // Construct full image URL
-    const imageUrl = artwork.imagePath ? `/images/artworks/${artwork.imagePath}` : '#artworks';
+    // Construct full image URL with proper basePath
+    let imageUrl = '#artworks';
+    if (artwork.imagePath) {
+      const rawPath = `/images/artworks/${artwork.imagePath}`;
+      imageUrl = getAssetPath ? getAssetPath(rawPath) : rawPath;
+    }
     
     // Get localized description
     const translate = t || ((key: string) => key);
@@ -446,8 +451,12 @@ export function buildDynamicSearchIndex(
   
   // Add 3D models
   for (const model of modelings) {
-    // Construct full image URL
-    const imageUrl = model.imagePath ? `/images/modeling/${model.imagePath}` : '#modeling';
+    // Construct full image URL with proper basePath
+    let imageUrl = '#modeling';
+    if (model.imagePath) {
+      const rawPath = `/images/modeling/${model.imagePath}`;
+      imageUrl = getAssetPath ? getAssetPath(rawPath) : rawPath;
+    }
     
     // Get localized description
     const translate = t || ((key: string) => key);


### PR DESCRIPTION
- Add getAssetPath parameter to buildDynamicSearchIndex function
- Use getAssetPath to properly resolve artwork and modeling image URLs
- Fix hardcoded paths that were missing basePath in production
- Pass getAssetPath function from AdvancedSearch component to ensure proper URL generation
- This fixes the issue where clicking artwork/modeling images in search results would navigate to incorrect paths without /Dulcets basePath on GitHub Pages

Changes:
- Modified buildDynamicSearchIndex to accept optional getAssetPath parameter
- Updated artwork and modeling URL generation to use getAssetPath when available
- Updated AdvancedSearch component to pass getAssetPath to buildDynamicSearchIndex
- Maintains backward compatibility with fallback to raw paths when getAssetPath not provided